### PR TITLE
Fix the coherent / incoherent separator incorrectly splitting at 10 GHz-s instead of 1e10 GHz-s

### DIFF
--- a/phase_space.c
+++ b/phase_space.c
@@ -124,7 +124,7 @@ int main ( int argc, char* argv[])
     fprintf(gnuplot, "set arrow from 2.0e5,4.0e3 to 2.0e7,10 lt -1 lw 2 front\n");
 
     /* Constant Brightness Temperature Lines */
-    fprintf(gnuplot, "replot L12(x) notitle w filledcurve x2=10 lt rgb '#87CEFA', L4(x) notitle lt 0 lw 2, L8(x) notitle lt 0 lw 2, L12(x) notitle lt 0 lw 2, L16(x) notitle lt 0 lw 2, L20(x) notitle lt 0 lw 2, L24(x) notitle lt 0 lw 2, L28(x) notitle lt 0 lw 2, L32(x) notitle lt 0 lw 2, L36(x) notitle lt 0 lw 2, L40(x) notitle lt 0 lw 2\n");
+    fprintf(gnuplot, "replot L12(x) notitle w filledcurve x2=1e10 lt rgb '#87CEFA', L4(x) notitle lt 0 lw 2, L8(x) notitle lt 0 lw 2, L12(x) notitle lt 0 lw 2, L16(x) notitle lt 0 lw 2, L20(x) notitle lt 0 lw 2, L24(x) notitle lt 0 lw 2, L28(x) notitle lt 0 lw 2, L32(x) notitle lt 0 lw 2, L36(x) notitle lt 0 lw 2, L40(x) notitle lt 0 lw 2\n");
   }
   if (psr==1){
     fprintf(gnuplot, "set label \"Pulsars\" front at 1.0e-7,1.0e-2 textcolor rgb '#0000FF'\n");


### PR DESCRIPTION
Just a quick fix as I was looking to use this figure and it wasn't coming out right, `gnuplot 5.2 patchlevel 8` encase this is just an issue with newer versions.


`gcc phase_space.c -o phase_space; ./phase_space -all -ps`

Before
[phase_space (another copy).pdf](https://github.com/FRBs/Transient_Phase_Space/files/5310888/phase_space.another.copy.pdf)


After
[phase_space.pdf](https://github.com/FRBs/Transient_Phase_Space/files/5310885/phase_space.pdf)
